### PR TITLE
feat: add blog post on four modes of AI collaboration

### DIFF
--- a/content/posts/2026-04-12-four-modes-of-ai-collaboration.md
+++ b/content/posts/2026-04-12-four-modes-of-ai-collaboration.md
@@ -1,5 +1,5 @@
 ---
-title: "Four Ways to Work With AI"
+title: "Four Modes of AI Collaboration"
 date: 2026-04-12
 draft: false
 tags:
@@ -40,3 +40,7 @@ The four modes aren't fixed buckets. A relationship that starts as Workshop can 
 This is where [agentic self-improvement](https://garden.hanneseichblatt.de/Agentic-Self-Improvement) becomes interesting: agents that actively reflect on past collaboration and refine their own context grow more capable at higher modes over time — not because the underlying model improves, but because the working relationship does. Karpathy's [append-and-review](https://karpathy.bearblog.dev/the-append-and-review-note/) concept is an early sketch of what this looks like in practice.
 
 The infrastructure you build shapes which modes are available to you. And the modes you can reach are the modes you'll use.
+
+---
+
+*This post was written in collaboration with Claude Opus, implementing the Workshop pattern described above.*

--- a/content/posts/2026-04-12-four-modes-of-ai-collaboration.md
+++ b/content/posts/2026-04-12-four-modes-of-ai-collaboration.md
@@ -11,7 +11,7 @@ Most people use AI the same way: type a question, read the answer. That's one of
 
 ## The Four Modes
 
-I've been developing [a taxonomy](https://garden.hanneseichblatt.de/AI-Engagement-Patterns) based on how much context the agent keeps and how much you specify up front:
+Four [engagement patterns](https://garden.hanneseichblatt.de/AI-Engagement-Patterns), differentiated by how much context the agent keeps and how much you specify up front:
 
 | Mode | Context | You give the agent |
 |------|---------|-------------------|
@@ -24,16 +24,16 @@ These aren't a hierarchy. Lookup is right for one-off questions; Mission for aut
 
 ## Abstraction is the Variable
 
-What shifts across the modes is the level of abstraction you bring. In Lookup you specify everything. In Mission you share an idea and the agent figures out the rest. Karpathy put it well: in the LLM era, you share the idea and [the agent customises and builds for your specific needs](https://garden.hanneseichblatt.de/Abstraction-and-Autonomy-in-Human-AI-Collaboration). The bottleneck in Mission mode isn't model capability — it's the quality of your task definition.
+What shifts across the modes is the level of abstraction you bring. In Lookup you specify everything. In Mission you share an idea and the agent figures out the rest. Karpathy put it well: in the LLM era, you share the idea and the agent [customises and builds for your specific needs](https://garden.hanneseichblatt.de/Abstraction-and-Autonomy-in-Human-AI-Collaboration). The bottleneck in Mission mode isn't model capability — it's the quality of your task definition.
 
 ## Infrastructure Follows
 
-Each mode has different cost, latency, and capability requirements. [Daniel Miessler's advice](https://danielmiessler.com/blog/inference-costs-are-not-sustainable): start planning your multi-model, local-model, cheaper-model strategy for your harness. A router that dispatches to local Ollama for Lookup and premium remote models for Mission is the natural architecture. More on this in my [Personal AI Infrastructure](https://garden.hanneseichblatt.de/Personal-AI-Infrastructure) note.
+Each mode has different cost, latency, and capability requirements. [Daniel Miessler's advice](https://danielmiessler.com/blog/inference-costs-are-not-sustainable): start planning your multi-model, local-model, cheaper-model strategy for your harness. A [router that dispatches](https://garden.hanneseichblatt.de/Personal-AI-Infrastructure) to local Ollama for Lookup and premium remote models for Mission is the natural architecture.
 
 This is a new ops problem.
 
 ## What Changes Over Time
 
-The modes aren't fixed. Agents that accumulate persistent memory — Karpathy's [append-and-review](https://karpathy.bearblog.dev/the-append-and-review-note/) concept applied to agent context, explored in my [Agentic Self-Improvement](https://garden.hanneseichblatt.de/Agentic-Self-Improvement) notes — become more capable at Companion and Mission work over time.
+The modes aren't fixed. Agents that [accumulate and refine context](https://garden.hanneseichblatt.de/Agentic-Self-Improvement) over time — Karpathy's [append-and-review](https://karpathy.bearblog.dev/the-append-and-review-note/) concept applied to agent memory — become more capable at Companion and Mission work without the models themselves changing.
 
 The infrastructure you build now determines which modes you can operate in. The modes you can support are the modes you will use.

--- a/content/posts/2026-04-12-four-modes-of-ai-collaboration.md
+++ b/content/posts/2026-04-12-four-modes-of-ai-collaboration.md
@@ -1,0 +1,54 @@
+---
+title: "Four Ways to Work With AI"
+date: 2026-04-12
+draft: false
+tags:
+    - tech
+    - comment
+---
+
+Most people I talk to use AI the same way: they type a question, read the answer, and move on. It's a better search engine. Occasionally a smarter autocomplete. That is a perfectly legitimate use, but it conflates four fundamentally different modes of working with AI into one — and the conflation has consequences, both for what you get out of AI and for how you build the infrastructure to support it.
+
+I've been thinking about a taxonomy of AI engagement patterns, and after a few weeks of refining it I think four categories cover most of what people actually do.
+
+## The Four Modes
+
+**Lookup** is the mode everyone knows. You ask a one-off question; the agent answers. No context is kept between exchanges. The interaction surface is a messenger-style chat window — stateless, frictionless, and exactly suited for things like "what does this regex mean" or "summarise this paragraph". You bring the full specification; the agent brings the answer.
+
+**Workshop** is an ephemeral collaborative session. User and agent work together toward a defined goal — say, a coding session, a document draft, or a debugging run. Context is shared within the session and discarded when it ends. The right tool here is a web UI paired with a coding agent and a git repository: enough structure to be productive, light enough that you don't carry the weight of everything you've ever done together. You bring a goal; the agent helps you reach it.
+
+**Companion** is what happens when you stop discarding context. The collaboration is persistent — it accumulates across sessions, building a shared understanding of how you work, what matters to you, what you've already tried. Infrastructure here starts to resemble a long-lived project: an ongoing agent configuration, a git-backed knowledge store, probably some form of memory layer. You bring a working relationship; the agent brings continuity.
+
+**Mission** is the autonomous end. You hand the agent a task definition — including what "done" looks like — and it works independently, asking for human approval at key decision points. The interaction surface is closer to a project management tool than a chat window: GitHub issues, pull requests, a Kanban board. You bring an abstract goal; the agent brings a completed result.
+
+These four modes are not a hierarchy of sophistication. They are appropriate to different types of work. Using Workshop mode for a quick factual question is wasteful. Using Lookup mode for a complex refactoring task is maddening. The failure to distinguish them is why a lot of AI-assisted work feels simultaneously overhyped and underdelivering.
+
+## Abstraction as the Variable
+
+What changes across the four modes is not really the capability of the model. It is the level of abstraction at which you engage with it.
+
+In Lookup, you specify everything. The question must be self-contained. The agent's latitude is narrow: it fills in what you already know you need. In Workshop, you specify a goal and leave the path open. In Companion, you specify less and less over time as the shared context fills in the gaps. In Mission, you specify an idea and the agent figures out everything else — the implementation, the tooling, the sequence of steps.
+
+Andrej Karpathy put a version of this neatly in a recent note: in the LLM era, you share the *idea*, and the other person's agent customises and builds it for your specific needs. The abstraction is the deliverable. You stop writing code and start writing intent.
+
+This is a non-trivial shift. It means that the bottleneck in Companion and Mission mode is not model capability but the quality of your task definition. Vague intent produces vague results. But the right kind of structured vagueness — clear about the goal, open about the path — gives agents room to optimise for your specific context rather than the imagined average case.
+
+## Infrastructure Follows the Mode
+
+Each mode has a different cost and latency profile, and a different requirement for model capability. Lookup is cheap and fast; a small local model usually suffices. Workshop needs something more capable but still latency-sensitive. Companion and Mission, running over longer horizons with larger context windows, can tolerate more latency and justify higher cost per token.
+
+The natural architecture for someone running all four modes is a router: a harness that enriches user input with context, then dispatches to an appropriate backend based on the engagement pattern. Local Ollama instances for Lookup-class work; a mid-tier hosted model for Workshop; a premium remote model for complex Companion and Mission tasks. Daniel Miesler put this concisely: start planning your multi-model, local-model, cheaper-model strategy for your harness.
+
+This is, effectively, an ops problem. Setting up personal AI infrastructure — understanding your usage patterns, choosing your backends, tuning your routing logic — is becoming a prerequisite for serious AI use in the same way that understanding package management became a prerequisite for serious software development. You can get far without it, but you will hit a ceiling.
+
+The ceiling is not about the models. It is about the infrastructure you bring to them.
+
+## What Comes Next
+
+The most interesting direction from here is Companion and Mission mode becoming more capable through time, not just through better models. Agents that maintain persistent memory and refine it in the background — Claude Code's approach to memory management reportedly involves a three-layer design with background rewriting — accumulate context that makes future interactions more effective. Karpathy's AI Librarian concept takes this further: a knowledge-base-in-context that an agent actively curates, distills, and queries.
+
+The implication is that the modes are not fixed categories. They evolve with use. A relationship that starts in Workshop mode — ephemeral, task-scoped — can graduate to Companion mode as shared context accumulates and trust is established. Mission mode becomes viable only after enough Companion-mode collaboration to know that the agent's defaults roughly match your intentions.
+
+The infrastructure you build now determines which modes you can operate in. If you only have a stateless chat window, you only have Lookup. The modes you can support are the modes you will use.
+
+That is probably the thing worth getting right before the models get any better.

--- a/content/posts/2026-04-12-four-modes-of-ai-collaboration.md
+++ b/content/posts/2026-04-12-four-modes-of-ai-collaboration.md
@@ -1,7 +1,6 @@
 ---
 title: "Four Modes of AI Collaboration"
 date: 2026-04-12
-draft: false
 tags:
     - tech
     - comment

--- a/content/posts/2026-04-12-four-modes-of-ai-collaboration.md
+++ b/content/posts/2026-04-12-four-modes-of-ai-collaboration.md
@@ -7,33 +7,36 @@ tags:
     - comment
 ---
 
-Most people use AI the same way: type a question, read the answer. That's one of four distinct modes — and conflating them is why AI-assisted work so often disappoints.
+Most people I know use AI the same way: type a question, get an answer, move on. That works fine — but it's one of four fundamentally different [engagement patterns](https://garden.hanneseichblatt.de/AI-Engagement-Patterns), and treating them as interchangeable is part of why AI-assisted work so often feels like it underdelivers.
 
 ## The Four Modes
 
-Four [engagement patterns](https://garden.hanneseichblatt.de/AI-Engagement-Patterns), differentiated by how much context the agent keeps and how much you specify up front:
+The patterns are best understood along two axes: how much context the agent keeps, and how much autonomy you give it.
 
-| Mode | Context | You give the agent |
-|------|---------|-------------------|
-| **Lookup** | None | A fully specified question |
-| **Workshop** | Ephemeral session | A goal |
-| **Companion** | Persistent | A working relationship |
-| **Mission** | Autonomous | A task definition |
+**Lookup** is stateless. You bring a fully specified question; the agent answers it; nothing carries over. It's the right tool for exactly what it sounds like — looking things up. Most people live here.
 
-These aren't a hierarchy. Lookup is right for one-off questions; Mission for autonomous execution. Using the wrong mode for the job — Workshop for a quick factual question, Lookup for a complex refactoring — is what produces the frustration.
+**Workshop** is an ephemeral session with a shared goal. You and an agent work together toward something, context is alive for the duration, and then it's gone. This is the mode that most coding agents and document editors are built around today.
+
+**Companion** is what happens when you stop discarding context. The collaboration accumulates across sessions — the agent develops a picture of how you work, what you care about, what you've tried before. Something that resembles a working relationship starts to form.
+
+**Mission** is the autonomous end. You hand over a task definition — including what "done" looks like — and the agent executes independently, checking back at decision points. You're managing a process, not driving one.
+
+These aren't a sophistication hierarchy. Using Workshop mode for a one-off question is overkill; using Lookup for a complex refactoring is maddening. The frustration most people feel with AI tools often comes from this mismatch, not from the models themselves.
 
 ## Abstraction is the Variable
 
-What shifts across the modes is the level of abstraction you bring. In Lookup you specify everything. In Mission you share an idea and the agent figures out the rest. Karpathy put it well: in the LLM era, you share the idea and the agent [customises and builds for your specific needs](https://garden.hanneseichblatt.de/Abstraction-and-Autonomy-in-Human-AI-Collaboration). The bottleneck in Mission mode isn't model capability — it's the quality of your task definition.
+What changes across the modes is the level of abstraction at which you engage. In Lookup, you do all the specifying — the question has to be self-contained. In Workshop, you specify a goal and leave the path open. In Companion, the accumulated context fills in gaps you no longer need to articulate. In Mission, you're operating at the level of intent.
 
-## Infrastructure Follows
+Karpathy captured this neatly: in the LLM era, [you share the idea and the agent builds it for your specific needs](https://garden.hanneseichblatt.de/Abstraction-and-Autonomy-in-Human-AI-Collaboration) — there's less and less point in sharing specific code. The abstraction becomes the deliverable. This is a real shift: the bottleneck in higher modes isn't what the model can do, it's how precisely you can articulate what you want at the right level of vagueness.
 
-Each mode has different cost, latency, and capability requirements. [Daniel Miessler's advice](https://danielmiessler.com/blog/inference-costs-are-not-sustainable): start planning your multi-model, local-model, cheaper-model strategy for your harness. A [router that dispatches](https://garden.hanneseichblatt.de/Personal-AI-Infrastructure) to local Ollama for Lookup and premium remote models for Mission is the natural architecture.
+## Infrastructure Has to Match
 
-This is a new ops problem.
+Each mode has a different cost and capability profile, and you can't run all four out of the same setup. [Daniel Miessler's framing](https://danielmiessler.com/blog/inference-costs-are-not-sustainable) is useful here: you need a strategy for routing between models — cheaper and faster for well-defined tasks, more capable for open-ended ones. The right [infrastructure](https://garden.hanneseichblatt.de/Personal-AI-Infrastructure) is less about having the most powerful model and more about dispatching intelligently. That's an ops problem most people haven't started thinking about yet.
 
-## What Changes Over Time
+## The Modes Evolve
 
-The modes aren't fixed. Agents that [accumulate and refine context](https://garden.hanneseichblatt.de/Agentic-Self-Improvement) over time — Karpathy's [append-and-review](https://karpathy.bearblog.dev/the-append-and-review-note/) concept applied to agent memory — become more capable at Companion and Mission work without the models themselves changing.
+The four modes aren't fixed buckets. A relationship that starts as Workshop can graduate to Companion as shared context accumulates. Mission becomes viable only once you've built enough trust in how the agent operates.
 
-The infrastructure you build now determines which modes you can operate in. The modes you can support are the modes you will use.
+This is where [agentic self-improvement](https://garden.hanneseichblatt.de/Agentic-Self-Improvement) becomes interesting: agents that actively reflect on past collaboration and refine their own context grow more capable at higher modes over time — not because the underlying model improves, but because the working relationship does. Karpathy's [append-and-review](https://karpathy.bearblog.dev/the-append-and-review-note/) concept is an early sketch of what this looks like in practice.
+
+The infrastructure you build shapes which modes are available to you. And the modes you can reach are the modes you'll use.

--- a/content/posts/2026-04-12-four-modes-of-ai-collaboration.md
+++ b/content/posts/2026-04-12-four-modes-of-ai-collaboration.md
@@ -7,48 +7,33 @@ tags:
     - comment
 ---
 
-Most people I talk to use AI the same way: they type a question, read the answer, and move on. It's a better search engine. Occasionally a smarter autocomplete. That is a perfectly legitimate use, but it conflates four fundamentally different modes of working with AI into one — and the conflation has consequences, both for what you get out of AI and for how you build the infrastructure to support it.
-
-I've been thinking about a taxonomy of AI engagement patterns, and after a few weeks of refining it I think four categories cover most of what people actually do.
+Most people use AI the same way: type a question, read the answer. That's one of four distinct modes — and conflating them is why AI-assisted work so often disappoints.
 
 ## The Four Modes
 
-**Lookup** is the mode everyone knows. You ask a one-off question; the agent answers. No context is kept between exchanges. The interaction surface is a messenger-style chat window — stateless, frictionless, and exactly suited for things like "what does this regex mean" or "summarise this paragraph". You bring the full specification; the agent brings the answer.
+I've been developing [a taxonomy](https://garden.hanneseichblatt.de/AI-Engagement-Patterns) based on how much context the agent keeps and how much you specify up front:
 
-**Workshop** is an ephemeral collaborative session. User and agent work together toward a defined goal — say, a coding session, a document draft, or a debugging run. Context is shared within the session and discarded when it ends. The right tool here is a web UI paired with a coding agent and a git repository: enough structure to be productive, light enough that you don't carry the weight of everything you've ever done together. You bring a goal; the agent helps you reach it.
+| Mode | Context | You give the agent |
+|------|---------|-------------------|
+| **Lookup** | None | A fully specified question |
+| **Workshop** | Ephemeral session | A goal |
+| **Companion** | Persistent | A working relationship |
+| **Mission** | Autonomous | A task definition |
 
-**Companion** is what happens when you stop discarding context. The collaboration is persistent — it accumulates across sessions, building a shared understanding of how you work, what matters to you, what you've already tried. Infrastructure here starts to resemble a long-lived project: an ongoing agent configuration, a git-backed knowledge store, probably some form of memory layer. You bring a working relationship; the agent brings continuity.
+These aren't a hierarchy. Lookup is right for one-off questions; Mission for autonomous execution. Using the wrong mode for the job — Workshop for a quick factual question, Lookup for a complex refactoring — is what produces the frustration.
 
-**Mission** is the autonomous end. You hand the agent a task definition — including what "done" looks like — and it works independently, asking for human approval at key decision points. The interaction surface is closer to a project management tool than a chat window: GitHub issues, pull requests, a Kanban board. You bring an abstract goal; the agent brings a completed result.
+## Abstraction is the Variable
 
-These four modes are not a hierarchy of sophistication. They are appropriate to different types of work. Using Workshop mode for a quick factual question is wasteful. Using Lookup mode for a complex refactoring task is maddening. The failure to distinguish them is why a lot of AI-assisted work feels simultaneously overhyped and underdelivering.
+What shifts across the modes is the level of abstraction you bring. In Lookup you specify everything. In Mission you share an idea and the agent figures out the rest. Karpathy put it well: in the LLM era, you share the idea and [the agent customises and builds for your specific needs](https://garden.hanneseichblatt.de/Abstraction-and-Autonomy-in-Human-AI-Collaboration). The bottleneck in Mission mode isn't model capability — it's the quality of your task definition.
 
-## Abstraction as the Variable
+## Infrastructure Follows
 
-What changes across the four modes is not really the capability of the model. It is the level of abstraction at which you engage with it.
+Each mode has different cost, latency, and capability requirements. [Daniel Miessler's advice](https://danielmiessler.com/blog/inference-costs-are-not-sustainable): start planning your multi-model, local-model, cheaper-model strategy for your harness. A router that dispatches to local Ollama for Lookup and premium remote models for Mission is the natural architecture. More on this in my [Personal AI Infrastructure](https://garden.hanneseichblatt.de/Personal-AI-Infrastructure) note.
 
-In Lookup, you specify everything. The question must be self-contained. The agent's latitude is narrow: it fills in what you already know you need. In Workshop, you specify a goal and leave the path open. In Companion, you specify less and less over time as the shared context fills in the gaps. In Mission, you specify an idea and the agent figures out everything else — the implementation, the tooling, the sequence of steps.
+This is a new ops problem.
 
-Andrej Karpathy put a version of this neatly in a recent note: in the LLM era, you share the *idea*, and the other person's agent customises and builds it for your specific needs. The abstraction is the deliverable. You stop writing code and start writing intent.
+## What Changes Over Time
 
-This is a non-trivial shift. It means that the bottleneck in Companion and Mission mode is not model capability but the quality of your task definition. Vague intent produces vague results. But the right kind of structured vagueness — clear about the goal, open about the path — gives agents room to optimise for your specific context rather than the imagined average case.
+The modes aren't fixed. Agents that accumulate persistent memory — Karpathy's [append-and-review](https://karpathy.bearblog.dev/the-append-and-review-note/) concept applied to agent context, explored in my [Agentic Self-Improvement](https://garden.hanneseichblatt.de/Agentic-Self-Improvement) notes — become more capable at Companion and Mission work over time.
 
-## Infrastructure Follows the Mode
-
-Each mode has a different cost and latency profile, and a different requirement for model capability. Lookup is cheap and fast; a small local model usually suffices. Workshop needs something more capable but still latency-sensitive. Companion and Mission, running over longer horizons with larger context windows, can tolerate more latency and justify higher cost per token.
-
-The natural architecture for someone running all four modes is a router: a harness that enriches user input with context, then dispatches to an appropriate backend based on the engagement pattern. Local Ollama instances for Lookup-class work; a mid-tier hosted model for Workshop; a premium remote model for complex Companion and Mission tasks. Daniel Miesler put this concisely: start planning your multi-model, local-model, cheaper-model strategy for your harness.
-
-This is, effectively, an ops problem. Setting up personal AI infrastructure — understanding your usage patterns, choosing your backends, tuning your routing logic — is becoming a prerequisite for serious AI use in the same way that understanding package management became a prerequisite for serious software development. You can get far without it, but you will hit a ceiling.
-
-The ceiling is not about the models. It is about the infrastructure you bring to them.
-
-## What Comes Next
-
-The most interesting direction from here is Companion and Mission mode becoming more capable through time, not just through better models. Agents that maintain persistent memory and refine it in the background — Claude Code's approach to memory management reportedly involves a three-layer design with background rewriting — accumulate context that makes future interactions more effective. Karpathy's AI Librarian concept takes this further: a knowledge-base-in-context that an agent actively curates, distills, and queries.
-
-The implication is that the modes are not fixed categories. They evolve with use. A relationship that starts in Workshop mode — ephemeral, task-scoped — can graduate to Companion mode as shared context accumulates and trust is established. Mission mode becomes viable only after enough Companion-mode collaboration to know that the agent's defaults roughly match your intentions.
-
-The infrastructure you build now determines which modes you can operate in. If you only have a stateless chat window, you only have Lookup. The modes you can support are the modes you will use.
-
-That is probably the thing worth getting right before the models get any better.
+The infrastructure you build now determines which modes you can operate in. The modes you can support are the modes you will use.


### PR DESCRIPTION
Based on recent garden notes: AI engagement patterns (Lookup/Workshop/
Companion/Mission), abstraction as the key variable, and personal AI
infrastructure as the new ops problem.

https://claude.ai/code/session_01HN2wBVWoYyb97bwzZmbbqh