### PR TITLE
Remove Twitter/X social links and privacy settings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ tags:
 
 The site uses the lightweight **hugo-paper** theme (git submodule at `themes/hugo-paper/`). Configuration is in `hugo.toml`:
 - Color scheme: `gray` (options: linen, wheat, gray, light)
-- Social links: Twitter, GitHub, LinkedIn, Mastodon
+- Social links: GitHub, LinkedIn, Mastodon
 - Taxonomies: tags, categories, series
 
 The theme supports shortcodes like `{{< youtube VIDEO_ID >}}` for embedding YouTube videos.

--- a/hugo.toml
+++ b/hugo.toml
@@ -13,7 +13,6 @@ ignoreErrors = ["error-remote-getjson"]
 [params]
   color = 'gray'   # linen, wheat, gray, light
 
-  twitter = 'heichblatt'
   github = 'heichblatt'
   linkedin = 'hanneseichblatt'
   mastodon = 'https://hachyderm.io/@heichblatt'
@@ -50,11 +49,6 @@ series = "series"
     disabled = false
     simple = true
 
-  [privacy.x]
-    disabled = false
-    enableDNT = true
-    simple = true
-
   [privacy.instagram]
     disabled = false
     simple = true
@@ -66,7 +60,4 @@ series = "series"
 [services]
 
   [services.instagram]
-    disableInlineCSS = true
-
-  [services.x]
     disableInlineCSS = true


### PR DESCRIPTION
This PR removes all references to Twitter/X from the site configuration and documentation.

## Summary
Removed Twitter/X integration from the Hugo site configuration, including social media links and privacy settings.

## Changes Made
- Removed `twitter = 'heichblatt'` from social links in `hugo.toml`
- Removed the entire `[privacy.x]` configuration section
- Removed the `[services.x]` configuration section
- Updated `CLAUDE.md` documentation to reflect that social links now only include GitHub, LinkedIn, and Mastodon (removed Twitter from the list)

## Details
The site no longer displays or processes Twitter/X embeds or social links. This simplifies the configuration and removes unnecessary privacy/service settings for a platform that is no longer being used for this site's social presence.

https://claude.ai/code/session_01LZn36izj2Ynvs73qWmt5Hw