### PR TITLE
Add file history link to blog post footer

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -24,6 +24,9 @@ Upstream issue: https://github.com/nanxiaobei/hugo-paper/issues/265
       <span class="mx-1">&middot;</span>
       <span>{{- $single_author -}}</span>
       {{- end -}}
+      <span class="mx-1">&middot;</span>
+      <a href="https://github.com/heichblatt/heichblatt.github.io/commits/master/content/{{- .File.Path -}}"
+         class="no-underline hover:underline">File history</a>
     </div>
     {{- end -}}
   </header>
@@ -44,14 +47,6 @@ Upstream issue: https://github.com/nanxiaobei/hugo-paper/issues/265
     >
     {{- end -}}
   </footer>
-  {{- end -}}
-
-  <!-- File History -->
-  {{- if ne .Type "page" -}}
-  <div class="mt-6 text-xs opacity-60">
-    <a href="https://github.com/heichblatt/heichblatt.github.io/commits/master/content/{{- .File.Path -}}"
-       class="no-underline hover:underline">File history</a>
-  </div>
   {{- end -}}
 
   <!-- Post Nav -->

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -46,6 +46,14 @@ Upstream issue: https://github.com/nanxiaobei/hugo-paper/issues/265
   </footer>
   {{- end -}}
 
+  <!-- File History -->
+  {{- if ne .Type "page" -}}
+  <div class="mt-6 text-xs opacity-60">
+    <a href="https://github.com/heichblatt/heichblatt.github.io/commits/master/content/{{- .File.Path -}}"
+       class="no-underline hover:underline">File history</a>
+  </div>
+  {{- end -}}
+
   <!-- Post Nav -->
   {{- if not site.Params.disablePostNavigation -}}<!---->
   {{- $pages := where site.RegularPages "Type" "in" site.Params.mainSections -}}<!---->


### PR DESCRIPTION
Closes #36

## Summary

- Adds a "File history" link at the bottom of each blog post
- Links to the GitHub commit log for that post's markdown source file
- Only rendered for posts (not static pages like About), using the `ne .Type "page"` guard
- Uses Hugo's `.File.Path` to construct the per-post URL: `https://github.com/heichblatt/heichblatt.github.io/commits/master/content/<file-path>`

## Test plan

- [ ] Visit a blog post and confirm the "File history" link appears below the tags
- [ ] Click the link and confirm it leads to the correct GitHub commit history for that post's file
- [ ] Visit the About page and confirm no "File history" link appears

https://claude.ai/code/session_01QTBnZN4YhiLYmxenC7cXYH

---
_Generated by [Claude Code](https://claude.ai/code/session_01QTBnZN4YhiLYmxenC7cXYH)_